### PR TITLE
Add GTK 4.6.0 as a module

### DIFF
--- a/page.codeberg.foreverxml.Random.json
+++ b/page.codeberg.foreverxml.Random.json
@@ -54,6 +54,32 @@
             ]
         },
         {
+            "name": "pango",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                  "type": "git",
+                  "url": "https://gitlab.gnome.org/GNOME/pango.git",
+                  "tag": "1.50.0"
+                }
+            ]
+        },
+        {
+            "name": "gtk",
+            "buildsystem": "meson",
+            "config-opts" : [
+                    "-Dbuild-examples=false",
+                    "-Dbuild-tests=false"
+            ],
+            "sources": [
+                {
+                  "type": "git",
+                  "url": "https://gitlab.gnome.org/GNOME/gtk.git",
+                  "tag": "4.6.0"
+                }
+            ]
+        },
+        {
             "name" : "libadwaita",
             "buildsystem": "meson",
             "config-opts" : [
@@ -64,7 +90,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                    "tag": "1.0.0.alpha.4"
+                    "tag": "1.0.1"
                 }
             ]
         },


### PR DESCRIPTION
Since the latest versions of GTK 4 are not yet available in the stable version of ~Freedesktop SDK~ GNOME runtime, including it as a project module solves the build issues.